### PR TITLE
Chrome widget working and fully visible with Last.fm's 2019 layout update

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -16,27 +16,10 @@ function renderWidget() {
         sidebarEl.insertBefore(widgetRootEl, sidebarEl.firstChild);
 
         ReactDOM.render(<Widget />, widgetRootEl);
-        var rectangle = widgetRootEl.getBoundingClientRect();
-        var children = widgetRootEl.parentElement.children;
-        var maxDistance = 0;
-        for (let i = 0; i < children.length; i++){
-            if (children[i] != widgetRootEl){
-                let otherRectangle = children[i].getBoundingClientRect();
-                let num = rectangle.bottom - otherRectangle.top;
-                if (otherRectangle.height > 0 && num > maxDistance){
-                    maxDistance = num;
-                }
-            }
-        }
-        for (let i = 0; i < children.length; i++){
-            if (children[i] != widgetRootEl){
-                let otherRectangle = children[i].getBoundingClientRect();
-                children[i].style.marginTop = otherRectangle.top.toString() + "px";
-                let newOtherRectangle = children[i].getBoundingClientRect();
-                let previousMarginDistance = newOtherRectangle.top - otherRectangle.top;
-                let num = otherRectangle.top - previousMarginDistance + maxDistance;
-                children[i].style.marginTop = num.toString() + "px";
-            }
+        var videoOrArtEl = sidebarEl.querySelector('.video-preview')
+            || sidebarEl.querySelector('.album-overview-cover-art');
+        if (videoOrArtEl) {
+            videoOrArtEl.style.marginTop = 0;
         }
     }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -16,6 +16,28 @@ function renderWidget() {
         sidebarEl.insertBefore(widgetRootEl, sidebarEl.firstChild);
 
         ReactDOM.render(<Widget />, widgetRootEl);
+        var rectangle = widgetRootEl.getBoundingClientRect();
+        var children = widgetRootEl.parentElement.children;
+        var maxDistance = 0;
+        for (let i = 0; i < children.length; i++){
+            if (children[i] != widgetRootEl){
+                let otherRectangle = children[i].getBoundingClientRect();
+                let num = rectangle.bottom - otherRectangle.top;
+                if (otherRectangle.height > 0 && num > maxDistance){
+                    maxDistance = num;
+                }
+            }
+        }
+        for (let i = 0; i < children.length; i++){
+            if (children[i] != widgetRootEl){
+                let otherRectangle = children[i].getBoundingClientRect();
+                children[i].style.marginTop = otherRectangle.top.toString() + "px";
+                let newOtherRectangle = children[i].getBoundingClientRect();
+                let previousMarginDistance = newOtherRectangle.top - otherRectangle.top;
+                let num = otherRectangle.top - previousMarginDistance + maxDistance;
+                children[i].style.marginTop = num.toString() + "px";
+            }
+        }
     }
 }
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,5 +1,6 @@
 export function getTitle() {
-    var titleEl = document.querySelector('h1.header-title');
+    var titleEl = document.querySelector('h1.header-title')
+        || document.querySelector('h1.header-new-title');
     if (titleEl) {
         var title = titleEl.textContent;
 
@@ -12,29 +13,12 @@ export function getTitle() {
 
         return title;
     }
-    else {
-        titleEl = document.querySelector('h1.header-new-title');
-        if (titleEl) {
-            var title = titleEl.textContent;
-
-            title = title.trim();
-
-            // remove song duration
-            title = title.replace(/ \(\d{1,2}:\d{1,2}\)$/, '');
-
-            title = title.trim();
-
-            return title;
-        }
-    }
     return null;
 }
 
 function getCrumb() {
-    var crumbEl = document.querySelector('a.header-crumb');
-    if (!crumbEl){
-        crumbEl = document.querySelector('a.header-new-crumb');
-    }
+    var crumbEl = document.querySelector('a.header-crumb')
+        || document.querySelector('a.header-new-crumb');
     return (crumbEl ? crumbEl.textContent.trim() : null);
 }
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -12,11 +12,29 @@ export function getTitle() {
 
         return title;
     }
+    else {
+        titleEl = document.querySelector('h1.header-new-title');
+        if (titleEl) {
+            var title = titleEl.textContent;
+
+            title = title.trim();
+
+            // remove song duration
+            title = title.replace(/ \(\d{1,2}:\d{1,2}\)$/, '');
+
+            title = title.trim();
+
+            return title;
+        }
+    }
     return null;
 }
 
 function getCrumb() {
     var crumbEl = document.querySelector('a.header-crumb');
+    if (!crumbEl){
+        crumbEl = document.querySelector('a.header-new-crumb');
+    }
     return (crumbEl ? crumbEl.textContent.trim() : null);
 }
 


### PR DESCRIPTION
I was able to get the Chrome widget to work on Last.fm's 2019 layout update by editing `parser.js`, namely adding support for references to `'h1.header-new-title'` and `'a.header-new-crumb'`. 

However, it seemed that even with the widget working, some of the other sidebar elements would sometimes overlap with the widget. 
For instance, on this page, the video is blocking the entire widget:
![beforeMainJsFix](https://user-images.githubusercontent.com/29964170/103111548-3b215180-461c-11eb-906f-a623ae3d7acf.png)
So I also edited `main.js` to move those sidebar elements down a certain amount, such that the widget is completely visible, like this:
![afterMainJsFix](https://user-images.githubusercontent.com/29964170/103111613-dca8a300-461c-11eb-9990-5e7588d9b4ad.png)
